### PR TITLE
Fixes #11, use SDK v1.11, send truck position, job JSON format refactor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,4 +10,6 @@ endif()
 
 add_subdirectory(scs-sdk)
 add_subdirectory(plugin)
-add_subdirectory(gui)
+if(NOT MINGW)
+    add_subdirectory(gui)
+endif()

--- a/README.md
+++ b/README.md
@@ -20,46 +20,83 @@ Applications stores job information in memory until it's sent to your API. If
 sending failed, eg. your API did not return expected HTTP code, applications
 tries to send it again later until it's sent successfully.
 
-## JSON Format
+## API Documentation
 
-Below is an example of JSON format sent to API when user takes a job or when
-user finishes the job.
+Current version `v1`.
+
+### URL
+
+Differents payload will be sent with `POST` request to
+`<API_URL>/<API_VERSION>/<MESSAGE>`. In rest of this document `<API_URL>` will
+refer to URL of `<API_URL>/<API_VERSION>`.
+
+API is being expected to response with HTTP code `200` on succes.
+
+### Job
+
+Jobs will be sent to API to `<API_URL>/job` when user takes a job or cancels
+or delivers it.
+
+Below is an example of JSON format for a job.
 
 ```
 {
     "game": "ets2",               // Game type (ets2, ats)
-    "onJob": true,
-    "delivered": false,
-    "distanceDriven": 10.0,       // Kilometers
-    "fuelConsumed": 8.2,          // Liters
-    "income": 6878                // In game specific units (€, $)
-    "trailerDamage": 0.0,         // Percentage (eg. 10.0 = 10%)
-    "cargoName": "Office Paper",
-    "cargoId": "paper",
-    "cargoMass": 18000.0,         // Kilograms
-    "sourceCity": "Tampere",
-    "sourceCityId": "tampere",
-    "sourceCompany": "Viljo Paperitehdas Oy",
-    "sourceCompanyId": "viljo_paper",
-    "destinationCity": "Helsinki",
-    "destinationCityId": "helsinki",
-    "destinationCompany": "Container Port",
-    "destinationCompanyId": "cont_port"
+    "status": 1,                  // 0 = FreeAsWind, 1 = OnJob, 2 = Cancelled, 3 = Delivered
+    "income": 6878,               // In game specific units (€, $)
+    "maxSpeed": 0.0,              // Maximum  speed during the delivery (can be negative)
+    "fuelConsumed": 0.0,          // Liters
+    "distance": {
+        "driven": 0.0,            // Kilometers
+        "planned": 248            // Planned trip distance kilometers
+    },
+    "cargo": {
+        "id": "paper",
+        "name": "Office Paper",
+        "mass": 18000.0           // Kilograms
+        "damage": 0.0,            // Percentage (e.g. 10.0 = 10%)
+    },
+    "source": {
+        "city": {
+            "id": "tampere",
+            "name": "Tampere"
+        },
+        "company": {
+            "id": "viljo_paper",
+            "name": "Viljo Paperitehdas Oy"
+        }
+    },
+    "destination": {
+        "city": {
+            "id": "helsinki",
+            "name": "Helsinki"
+        },
+        "company": {
+            "id": "cont_port",
+            "name": "Container Port"
+        }
+    }
 }
+
 ```
 
-**API:**
+### Truck
 
-Payload will be sent with `POST` request to `<API_URL>/job`. Expected response
-code is `200`.
+Trucks positional data will be sent to `<API_URL>/truck` once in a second only
+if game is not paused.
 
-**User takes a job:**
+Below is an example of JSON format for a truck positional data.
 
-`onJob` will be `true` and `delivered` will be `false`.
+```
+{
+    "speed": 0.0,
+    "heading": 0.723,
+    "x": 34496.559,
+    "y": 11.938,
+    "z": -61094.948
+}
 
-**User finished the job:**
-
-`onJob` will be `false` and `delivered` will be `true`.
+```
 
 ## Building
 

--- a/gui/CMakeLists.txt
+++ b/gui/CMakeLists.txt
@@ -30,7 +30,7 @@ set(SOURCES
 
 find_package(wxWidgets 3.0 REQUIRED)
 include(${wxWidgets_USE_FILE})
-if (MSVC)
+if(MSVC)
     find_package(PNG REQUIRED)
     set(Boost_USE_STATIC_LIBS ON)
     find_package(Boost REQUIRED COMPONENTS random)
@@ -41,7 +41,7 @@ find_package(ZLIB REQUIRED)
 find_package(OpenSSL REQUIRED)
 find_package(CURL REQUIRED)
 find_package(OpenSSL REQUIRED)
-if (MSVC)
+if(MSVC)
     find_package(jsoncpp CONFIG REQUIRED)
     set(JSONCPP_LIBRARIES jsoncpp_lib_static)
     set(JSONCPP_INCLUDE_DIRS jsoncpp_lib_static)
@@ -50,7 +50,7 @@ else()
     pkg_check_modules(JSONCPP jsoncpp REQUIRED)
 endif()
 
-if (NOT WIN32)
+if(NOT WIN32)
     if (PLUGIN_PATH)
         set(PLUGIN_INSTALL_PATH ${PLUGIN_PATH})
     else()
@@ -63,7 +63,7 @@ configure_file(Logger/PluginInstallerDefs.h.in PluginInstallerDefs.h)
 
 add_executable(ets2-job-logger WIN32 ${SOURCES})
 
-if (MINGW)
+if(MINGW)
     set(WIN32_LIBS -lws2_32)
 elseif (WIN32)
     find_library(WS2_32_LIB ws2_32.lib REQUIRED)
@@ -108,7 +108,7 @@ target_compile_options(ets2-job-logger
                        ${JSON_CPP_CFLAGS_OTHER}
                        )
 
-if (DEVELOPMENT)
+if(DEVELOPMENT)
     target_compile_options(ets2-job-logger
                            PRIVATE
                            -DDEVELOPMENT=1

--- a/gui/Logger/JobSender.h
+++ b/gui/Logger/JobSender.h
@@ -40,7 +40,7 @@ public:
     /**
      * Start job sender
      *
-     * @return true if started, false otherwise
+     * @return bool - true if started, false otherwise
      */
     bool start();
 
@@ -52,22 +52,29 @@ public:
     /**
      * Has messages in queue to be sent to API
      *
-     * @return true if message in queue, false otherwise
+     * @return bool - true if message in queue, false otherwise
      */
     bool hasPending();
 
     /**
-     * Send job to API
+     * Add job information to send queue
      *
      * @param job
      */
     void send(const job_t &job);
 
+    /**
+     * Add truck information to send queue
+     *
+     * @param truck
+     */
+    void send(const truck_t &truck);
+
 private:
     /**
      * Main loop
      *
-     * @return
+     * @return wxThread::ExitCode
      */
     wxThread::ExitCode Entry() override;
 
@@ -75,7 +82,7 @@ private:
      * Generate full URL to endpoint
      *
      * @param endpoint
-     * @return
+     * @return std::string
      */
     std::string generate_url(const std::string &endpoint);
 
@@ -83,9 +90,18 @@ private:
      * Send job information to the API
      *
      * If sending failed, message is pushed back to queue
-     * @return true if job was sent successfully, false otherwise
+     *
+     * @return bool - true if job was sent successfully, false otherwise
      */
     bool send_job();
+
+    /**
+     * Send truck information to the API
+     *
+     * Response from server is ignored and message
+     * will not be sent again.
+     */
+    void send_truck();
 
     /**
      * Wrapper to send data to the API
@@ -93,7 +109,7 @@ private:
      * @param url - Full URL
      * @param data - Data to send
      * @param error - Error message
-     * @return true if sent successfully, false otherwise
+     * @return bool - true if sent successfully, false otherwise
      */
     bool send_data(const std::string &url, const char *data, wxString &error);
 
@@ -105,6 +121,7 @@ private:
     bool m_running;
     bool m_sending;
     std::vector<job_t> m_job_queue;
+    std::deque<truck_t> m_truck_queue;
 };
 
 #endif //ETS2_JOB_LOGGER_JOBSENDER_H

--- a/gui/MainWindow.h
+++ b/gui/MainWindow.h
@@ -121,6 +121,8 @@ private:
     JobSender *m_sender;
     Settings *m_settings;
     job_t m_job;
+    float m_odometerOnStart;
+    float m_fuelOnStart;
 
     bool m_socket_running;
     std::mutex m_socket_lock;

--- a/gui/base/MainWindow.cpp
+++ b/gui/base/MainWindow.cpp
@@ -101,9 +101,9 @@ MainWindow::MainWindow( wxWindow* parent, wxWindowID id, const wxString& title, 
 	m_staticTextTrailerDamage->Wrap( -1 );
 	fgSizer3->Add( m_staticTextTrailerDamage, 0, wxALL, 5 );
 
-	m_lblTrailerDamage = new wxStaticText( sbSizer3->GetStaticBox(), wxID_ANY, wxT("-"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_lblTrailerDamage->Wrap( -1 );
-	fgSizer3->Add( m_lblTrailerDamage, 0, wxALL, 5 );
+	m_lblCargoDamage = new wxStaticText( sbSizer3->GetStaticBox(), wxID_ANY, wxT("-"), wxDefaultPosition, wxDefaultSize, 0 );
+	m_lblCargoDamage->Wrap( -1 );
+	fgSizer3->Add( m_lblCargoDamage, 0, wxALL, 5 );
 
 	wxStaticText* m_staticTextDriven;
 	m_staticTextDriven = new wxStaticText( sbSizer3->GetStaticBox(), wxID_ANY, wxT("Distance driven:"), wxDefaultPosition, wxDefaultSize, 0 );

--- a/gui/base/MainWindow.fbp
+++ b/gui/base/MainWindow.fbp
@@ -817,7 +817,7 @@
                                         <property name="minimize_button">0</property>
                                         <property name="minimum_size"></property>
                                         <property name="moveable">1</property>
-                                        <property name="name">m_staticTextTrailerDamage</property>
+                                        <property name="name">m_staticTextCargoDamage</property>
                                         <property name="pane_border">1</property>
                                         <property name="pane_position"></property>
                                         <property name="pane_size"></property>
@@ -878,7 +878,7 @@
                                         <property name="minimize_button">0</property>
                                         <property name="minimum_size"></property>
                                         <property name="moveable">1</property>
-                                        <property name="name">m_lblTrailerDamage</property>
+                                        <property name="name">m_lblCargoDamage</property>
                                         <property name="pane_border">1</property>
                                         <property name="pane_position"></property>
                                         <property name="pane_size"></property>

--- a/gui/base/MainWindow.h
+++ b/gui/base/MainWindow.h
@@ -41,7 +41,7 @@ namespace base
 			wxStaticText* m_lblDestination;
 			wxStaticText* m_lblMass;
 			wxStaticText* m_lblIncome;
-			wxStaticText* m_lblTrailerDamage;
+			wxStaticText* m_lblCargoDamage;
 			wxStaticText* m_lblDistanceDriven;
 			wxStaticText* m_lblFuelConsumed;
 

--- a/plugin/CMakeLists.txt
+++ b/plugin/CMakeLists.txt
@@ -1,26 +1,44 @@
 project(plugin VERSION 0.1.0)
 
-add_library(${PROJECT_NAME}
-            OBJECT
-            include/jobplugin/PluginDefs.h
+set(SRCS
+    include/jobplugin/PluginDefs.h
 
-            src/Logger.cpp
-            src/Logger.h
+    src/Logger.cpp
+    src/Logger.h
 
-            src/main.cpp
-            )
-
-set_property(TARGET ${PROJECT_NAME} PROPERTY POSITION_INDEPENDENT_CODE ON)
+    src/main.cpp
+    )
 
 configure_file(include/jobplugin/Version.h.in "include/jobplugin/Version.h")
 
 if(MSVC)
-    set(PLUGIN_DLL_DEF plugin.def)
-endif()
+    add_library(${PROJECT_NAME} OBJECT ${SRCS})
+    add_library(plugin_shared SHARED $<TARGET_OBJECTS:${PROJECT_NAME}> plugin.def)
+    add_library(plugin_static STATIC $<TARGET_OBJECTS:${PROJECT_NAME}>)
 
+    set_target_properties(plugin_shared
+                          PROPERTIES
+                          OUTPUT_NAME "ets2-job-logger"
+                          PREFIX ""
+                          )
+
+    set_target_properties(plugin_static
+                          PROPERTIES
+                          OUTPUT_NAME "ets2-job-logger"
+                          PREFIX ""
+                          )
+
+    set_property(TARGET ${PROJECT_NAME} PROPERTY POSITION_INDEPENDENT_CODE ON)
+else()
+    add_library(${PROJECT_NAME} SHARED ${SRCS})
+
+    set_target_properties(${PROJECT_NAME}
+                          PROPERTIES
+                          OUTPUT_NAME "ets2-job-logger"
+                          PREFIX ""
+                          )
+endif()
 add_library(ets2joblogger::plugin ALIAS ${PROJECT_NAME})
-add_library(plugin_shared SHARED $<TARGET_OBJECTS:${PROJECT_NAME}> ${PLUGIN_DLL_DEF})
-add_library(plugin_static STATIC $<TARGET_OBJECTS:${PROJECT_NAME}>)
 
 find_package(msgpack REQUIRED)
 find_package(websocketpp REQUIRED)
@@ -33,31 +51,19 @@ if(WIN32)
 endif()
 
 if(MINGW)
-    set(WIN32_LIBS
-        -lwsock32
-        -lws2_32
-        -static-libgcc
-        -static-libstdc++
-        -Wl,-Bstatic -lstdc++ -lpthread -Wl,-Bdynamic
-        )
+    target_link_libraries(${PROJECT_NAME}
+                          PRIVATE
+                          -lwsock32
+                          -lws2_32
+                          -static-libgcc
+                          -static-libstdc++
+                          -Wl,-Bstatic -lstdc++ -lpthread -lssp -Wl,-Bdynamic
+                          )
 endif()
-
-set_target_properties(plugin_shared
-                      PROPERTIES
-                      OUTPUT_NAME "ets2-job-logger"
-                      PREFIX ""
-                      )
-
-set_target_properties(plugin_static
-                      PROPERTIES
-                      OUTPUT_NAME "ets2-job-logger"
-                      PREFIX ""
-                      )
 
 target_link_libraries(${PROJECT_NAME}
                       PRIVATE
                       scs::sdk
-                      ${WIN32_LIBS}
                       )
 
 target_include_directories(${PROJECT_NAME}

--- a/plugin/src/Logger.h
+++ b/plugin/src/Logger.h
@@ -66,6 +66,20 @@ public:
     SCSAPI_VOID fuel(const scs_value_t *const liters);
 
     /**
+     * Truck speed callback
+     *
+     * @param speed
+     */
+    SCSAPI_VOID speed(const scs_value_t *const speed);
+
+    /**
+     * Truck placement callback
+     *
+     * @param placement
+     */
+    SCSAPI_VOID truckPlacement(const scs_value_t *const placement);
+
+    /**
      * Trailer connected callback
      *
      * @param connected
@@ -73,18 +87,25 @@ public:
     SCSAPI_VOID trailerConnected(const scs_value_t *const connected);
 
     /**
-     * Trailer damage callback
-     *
-     * @param damage
-     */
-    SCSAPI_VOID trailerDamage(const scs_value_t *const damage);
-
-    /**
-     * Frame start callback
+     * Frame end callback
      *
      * @param event_info
      */
-    SCSAPI_VOID frameStart(const scs_telemetry_frame_start_t *event_info);
+    SCSAPI_VOID frameEnd(const void *const event_info);
+
+    /**
+     * Telemetry paused callback
+     *
+     * @param event_info
+     */
+    SCSAPI_VOID eventPaused(const void *const event_info);
+
+    /**
+     * Telemetry started callback
+     *
+     * @param event_info
+     */
+    SCSAPI_VOID eventStarted(const void *const event_info);
 
     /**
      * Configuration callback
@@ -92,6 +113,14 @@ public:
      * @param event_info
      */
     SCSAPI_VOID configuration(const scs_telemetry_configuration_t *event_info);
+
+    /**
+     * Gameplay callback
+     *
+     * @param event_info
+     */
+    SCSAPI_VOID gameplay(const scs_telemetry_gameplay_event_t *event_info);
+
 private:
     /**
      * Websocket server mainloop
@@ -109,9 +138,9 @@ private:
     void send_job();
 
     /**
-     * Send partial job information
+     * Send truck information
      */
-    void send_job_partial();
+    void send_truck_info();
 
     /**
      * Send data via websocket
@@ -141,10 +170,11 @@ private:
     std::set<websocketpp::connection_hdl,std::owner_less<websocketpp::connection_hdl>> m_connections;
 
     Game m_game;
-    std::time_t m_last_sent;
-    truck_t m_truck;
+    bool m_paused;
     job_t m_job;
-    float m_odometerOnStart;
+    truck_t m_truck;
+
+    std::chrono::steady_clock::time_point m_truckLastSent;
 };
 
 


### PR DESCRIPTION
Improved logic to determine job status.
Moved logic to calculate fuel consumption and driven distance to GUI.
Refactored job JSON format; replaced 'onJob' and 'delivered' with 'status', added maxSpeed and planned trip distance.
Implemented truck position tracking.
Use SCS SDK v1.11.
Updated API documentation in README.md
Build static version of the plugin only in Windows.