### PR TITLE
Fix #45, new fine types from SDK v1.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,13 +222,16 @@ Valid `Types` are:
 2  = AvoidSleeping
 3  = WrongWay
 4  = SpeedingCamera
-5  = Speeding
-6  = NoLights
-7  = RedSignal
-8  = Sleeping
-9  = AvoidWeighing
-10 = IllegalTrailer
-11 = Generic = 11
+5  = NoLights
+6  = RedSignal
+7  = Speeding
+8  = AvoidWeighing
+9  = IllegalTrailer
+10 = AvoidInspection
+11 = IllegalBorderCrossing
+12 = HardShoulderViolation
+13 = DamagedVehicleUsage
+14 = Generic
 ```
 
 If API receives fine with type `Unknown` then create an issue (if does not

--- a/plugin/include/jobplugin/PluginDefs.h
+++ b/plugin/include/jobplugin/PluginDefs.h
@@ -60,13 +60,16 @@ enum class Fine {
     AvoidSleeping = 2,
     WrongWay = 3,
     SpeedingCamera = 4,
-    Speeding = 5,
-    NoLights = 6,
-    RedSignal = 7,
-    Sleeping = 8,
-    AvoidWeighing = 9,
-    IllegalTrailer = 10,
-    Generic = 11
+    NoLights = 5,
+    RedSignal = 6,
+    Speeding = 7,
+    AvoidWeighing = 8,
+    IllegalTrailer = 9,
+    AvoidInspection = 10,
+    IllegalBorderCrossing = 11,
+    HardShoulderViolation = 12,
+    DamagedVehicleUsage = 13,
+    Generic = 14
 };
 MSGPACK_ADD_ENUM(Fine);
 

--- a/plugin/src/Logger.cpp
+++ b/plugin/src/Logger.cpp
@@ -302,6 +302,14 @@ Fine Logger::string_to_fine(const std::string &str) {
         ret = Fine::AvoidWeighing;
     } else if (str == "illegal_trailer") {
         ret = Fine::IllegalTrailer;
+    } else if (str == "avoid_inspection") {
+        ret = Fine::AvoidInspection;
+    } else if (str == "illegal_border_crossing") {
+        ret = Fine::IllegalBorderCrossing;
+    } else if (str == "hard_shoulder_violation") {
+        ret = Fine::HardShoulderViolation;
+    } else if (str == "damaged_vehicle_usage") {
+        ret = Fine::DamagedVehicleUsage;
     } else if (str == "generic") {
         ret = Fine::Generic;
     }

--- a/plugin/src/Logger.h
+++ b/plugin/src/Logger.h
@@ -132,7 +132,7 @@ private:
      * @param str
      * @return Fine - Fine type
      */
-    Fine string_to_fine(const std::string &str);
+    static Fine string_to_fine(const std::string &str);
 
     /**
      * Websocket server mainloop


### PR DESCRIPTION
- Updated scs-sdk submodule to v1.12
- Added the new fine types which are now provided by the SDK.
- Removed unused `Fine::Sleeping` (SDK only has `avoid_sleeping`)